### PR TITLE
changed en to en_core_web_sm

### DIFF
--- a/datasist/nlp.py
+++ b/datasist/nlp.py
@@ -4,8 +4,8 @@ This module contains all functions relating to nlp
 import re
 import os
 import spacy 
-os.system("python -m spacy download en")
-nlp_m = spacy.load('en')
+os.system("python -m spacy download en_core_web_sm")
+nlp_m = spacy.load('en_core_web_sm')
 from spacy.lang.en.stop_words import STOP_WORDS
 
 


### PR DESCRIPTION
Got the error 'can't find model 'en'' on importing datasist. On changing it to 'en_core_web_sm' it worked on the nlp.py file